### PR TITLE
Improve item-driven branches and narrative depth

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,6 +441,12 @@ const navWrap=document.getElementById('navWrap');
 const navToggle=document.getElementById('navToggle');
 const navMenu=document.getElementById('navMenu');
 const slotLabel=idx=>String(idx+1).padStart(2,'0');
+const hasItem=name=>ST.inv.includes(name);
+function gainItem(name){
+  if(!ST.inv.includes(name)){
+    ST.inv.push(name);
+  }
+}
 
 function updateViewIndicator(v){const badge=$('#viewIndicator'); if(badge){badge.textContent='Vue : '+(VIEW_LABELS[v]||'Tous');}}
 function openNavMenu(){if(!navWrap)return;navWrap.classList.add('open');if(navToggle)navToggle.setAttribute('aria-expanded','true');}
@@ -660,8 +666,9 @@ if(kabeClose){
 const SC={
  prologue:{
   img:IMG.pro,title:'Prologue — La Sourdine',text:()=>`
-  <p>La pluie plaque les enseignes de la Place du Pont. Sous <b>la Sourdine</b>, les voix deviennent feutrées et les souvenirs glissent. La sous-station <b>T1</b> décroche : si elle lâche, la Guill’ s’assombrit.</p>
-  <p>Il te faut un itinéraire sûr. <i>Noor</i> connaît les caves, <i>Milo</i> négocie avec les guetteurs, ou tu peux lire seul·e le courant de la foule.</p>`,
+  <p>La pluie plaque les enseignes de la Place du Pont et étire les halos des néons. Sous <b>la Sourdine</b>, les voix deviennent feutrées, les souvenirs glissent et ton HUD vacille par à-coups.</p>
+  <p>La sous-station <b>T1</b> décroche du réseau : si elle lâche, la Guill’ s’assombrit et les voies d’évacuation se referment.</p>
+  <p>Il te faut un itinéraire sûr. <i>Noor</i> connaît les caves, <i>Milo</i> négocie avec les guetteurs, ou tu peux lire seul·e le courant qui serpente sous la pluie.</p>`,
   choices:[
     {label:'Retrouver Noor, la dormeuse du pont',hint:'Guide discret vers les Berges (furtivité)',go:'place_noor'},
     {label:'Marcher vers Milo, le revendeur',hint:'Passe-droit potentiel au Pont',go:'place_milo'},
@@ -670,8 +677,8 @@ const SC={
  },
  place_noor:{
  img:IMG.place,title:'Place du Pont — Noor',text:()=>`
-  <p>Noor s’abrite sous une bâche plastique. Regard calme mais précis. Elle connaît les caves qui mènent aux <b>Berges</b>.</p>
-  <p>Elle ouvrira la voie si tu récupères <b>son sac</b> oublié à <b>Mazagran</b>.</p>`,
+  <p>Noor s’abrite sous une bâche plastique, capuche rabattue, regard calme mais précis. Elle connaît les caves qui mènent aux <b>Berges</b> et repère déjà les issues derrière toi.</p>
+  <p>Elle ouvrira la voie si tu récupères <b>son sac</b> oublié à <b>Mazagran</b>, celui qui contient un feuillet d’itinéraires griffonné à la main.</p>`,
   choices:[
     {label:'Accepter et récupérer son sac',hint:'Nouvel objectif : ramener le sac de Noor',immediate:s=>{s.tags.add('Noor');s.objective='Ramener le sac de Noor pour ouvrir la voie des caves.';addObj('Nouvel objectif : rapporter le sac de Noor.');},go:'maz_noor'},
     {label:'Refuser mais prendre son indice',hint:'Indice de trappe sans accompagnement',immediate:s=>{s.tags.add('Indice_Trappe');s.objective='Trouver la trappe technique indiquée par Noor.';addObj('Indice obtenu : emplacement de la trappe.');},go:'maz_common'},
@@ -680,8 +687,8 @@ const SC={
  },
  place_milo:{
  img:IMG.place,title:'Place du Pont — Milo',text:()=>`
-  <p>Milo recompte des câbles sous un parapluie troué. Il peut obtenir un laissez-passer au <b>Pont</b> si tu récupères un <b>coffret</b> caché à <b>Mazagran</b>.</p>
-  <p>Le deal est clair : tu rapportes le coffret, il parle aux guetteurs.</p>`,
+  <p>Milo recompte des câbles sous un parapluie troué. Son réseau alimente les guetteurs du <b>Pont</b>. Il peut obtenir un laissez-passer si tu récupères un <b>coffret</b> caché à <b>Mazagran</b>.</p>
+  <p>Le deal est clair : tu rapportes le coffret, il parle aux guetteurs et partage un code de reconnaissance gravé sur le plomb.</p>`,
   choices:[
     {label:'Accepter le deal du coffret',hint:'Passe-droit à gagner si tu réussis',immediate:s=>{s.tags.add('Milo');s.objective='Ramener le coffret scellé à Milo pour obtenir le passe.';addObj('Nouvel objectif : récupérer le coffret de Milo.');},go:'maz_milo'},
     {label:'Refuser et rester indépendant·e',hint:'Route neutre vers Mazagran',immediate:s=>{s.objective='Chercher un passage neutre par Mazagran.';},go:'maz_common'},
@@ -690,8 +697,8 @@ const SC={
  },
  place_solo:{
  img:IMG.place,title:'Place du Pont — Lire la foule',text:()=>`
-  <p>Tu te laisses porter par la foule. La pluie trace des courants sur le bitume. Tout converge vers <b>Mazagran</b> avant de glisser vers les <b>Berges</b>.</p>
-  <p>Reste à décider si tu suis le courant ou si tu forces un passage direct.</p>`,
+  <p>Tu te laisses porter par la foule. La pluie trace des courants sur le bitume et les rumeurs roulent d’un abri à l’autre. Tout converge vers <b>Mazagran</b> avant de glisser vers les <b>Berges</b>.</p>
+  <p>Reste à décider si tu suis le courant, si tu glanes des indices sous l’auvent ou si tu forces un passage direct.</p>`,
   choices:[
     {label:'Suivre le flux jusqu’à Mazagran',hint:'Collecter des indices avant les Berges',go:'maz_common'},
     {label:'Forcer un passage vers les Berges',hint:'Contourner la friche sans aide',go:'ber_entry'},
@@ -723,7 +730,10 @@ const SC={
    if(ST.tags.has('Collectif_Favor')&&!ST.tags.has('Collectif_Pret')){
     arr.push({label:'Prévenir le Collectif de ton départ',hint:'Prépare une escorte sociale',immediate:s=>{s.tags.add('Collectif_Pret');s.objective='Rejoindre le Pont avec l’appui du Collectif.';addObj('Le Collectif prépare une escorte pour le Pont.');},go:'place_return'});
    }
-   arr.push({label:'Rejoindre l’assemblée sous l’auvent',hint:'Chercher des appuis sociaux',go:'place_collectif'});
+   if(hasItem('Feuillet-mica')&&!ST.tags.has('Feuillet_Map')){
+    arr.push({label:'Déplier le feuillet-mica',hint:'Cartographier un conduit oublié vers T1',immediate:s=>{s.tags.add('Feuillet_Map');s.objective='Suivre les repères du feuillet vers une gaine discrète.';addObj('Les tracés UV du feuillet révèlent un détour sûr.');},go:'place_return'});
+   }
+    arr.push({label:'Rejoindre l’assemblée sous l’auvent',hint:'Chercher des appuis sociaux',go:'place_collectif'});
    arr.push({label:'Retourner vers Mazagran',hint:'Explorer la friche encore humide',go:'maz_common'});
    arr.push({label:'Descendre vers les Berges',hint:'Retrouver la trappe technique',go:'ber_entry'});
    arr.push({label:'S’approcher du Pont',hint:'Tester les contrôles en place',go:'pon_pass'});
@@ -735,6 +745,7 @@ const SC={
   <p>Sous l’auvent, des tables pliantes croulent sous les radios démontées. Les membres du Collectif griffonnent des plans pour contourner la Sourdine.</p>
   <p>Ils peuvent fournir escortes, rumeurs ou accès techniques si tu prouves ta valeur.</p>`,
   choices:[
+    {label:'Partager la note marquée de Milo',hint:'Utiliser la recommandation pour convaincre',when:()=>hasItem('Note marquée')&&!ST.tags.has('Collectif_Favor'),immediate:s=>{s.tags.add('Collectif_Favor');s.objective='Le Collectif peut préparer une escorte vers le Pont.';addObj('La note marquée circule sous l’auvent : confiance gagnée.');},go:'place_return'},
     {label:'Partager ton itinéraire',hint:'VOL/Empathie (10) — obtenir une escorte',when:()=>!ST.tags.has('Collectif_Favor'),test:{stat:'VOL',skill:'Empathie',dd:10,
       ok:s=>{s.tags.add('Collectif_Favor');s.objective='Le Collectif peut préparer une escorte vers le Pont.';addObj('Le Collectif accepte de couvrir ton passage.');},
       ko:s=>{s.stress=Math.min(5,s.stress+1);log('La discussion s’échauffe. +1 Stress.');}
@@ -744,7 +755,7 @@ const SC={
       ko:s=>{s.stress=Math.min(5,s.stress+1);log('Un regard te fixe. +1 Stress.');}
     },goOK:'place_return',goKO:'place_collectif'},
     {label:'Rétablir leur relais radio',hint:'NEU/Mécanique (11) — badge de maintenance',when:()=>!ST.tags.has('BadgeTech'),test:{stat:'NEU',skill:'Mécanique',dd:11,
-      ok:s=>{if(!s.inv.includes('Badge maintenance'))s.inv.push('Badge maintenance');s.tags.add('BadgeTech');s.objective='Utiliser le badge pour contourner la surveillance du Pont.';addObj('Badge de maintenance prêt pour les contrôles.');},
+      ok:s=>{gainItem('Badge maintenance');s.tags.add('BadgeTech');s.objective='Utiliser le badge pour contourner la surveillance du Pont.';addObj('Badge de maintenance prêt pour les contrôles.');},
       ko:s=>{s.hp=Math.max(0,s.hp-1);log('Une étincelle te mord. +1 Blessure.');}
     },goOK:'place_return',goKO:'place_collectif'},
     {label:'Revenir vers la Place principale',hint:'Faire le point avec tes contacts',go:'place_return'}
@@ -756,7 +767,7 @@ const SC={
   choices:[
     {label:'Lire le feuillet annoté',hint:'NEU/Mnémographie (10) — repérer la trappe',test:{stat:'NEU',skill:'Mnémographie',dd:10,
       ok:s=>{s.tags.add('Motif_R');s.objective='Atteindre la trappe technique depuis les Berges.';addObj('Indice : localisation de la trappe technique vers T1.');},ko:s=>{s.stress=Math.min(5,s.stress+1);log('Le motif te vrille. +1 Stress.')}}},
-    {label:'Saisir le coffret scellé',hint:'Ajouter l’objet à ton inventaire',immediate:s=>{s.inv.push('Coffret scellé');s.objective='Transporter le coffret sans attirer l’attention.';addObj('Coffret scellé rangé dans ton sac.');}},
+    {label:'Saisir le coffret scellé',hint:'Ajouter l’objet à ton inventaire',immediate:s=>{gainItem('Coffret scellé');s.objective='Transporter le coffret sans attirer l’attention.';addObj('Coffret scellé rangé dans ton sac.');}},
     {label:'Franchir la porte du Kabé',hint:'Respirer un instant loin de la Sourdine',when:()=>ST.stress>0&&!ST.tags.has('Kabe_Apero'),go:'maz_apero'},
     {label:'Descendre vers les Berges',hint:'Prendre la cave jusqu’aux darses',go:'ber_entry'},
     {label:'Se faufiler vers l’atelier latéral',hint:'Rencontrer les ouvriers de la friche',go:'maz_atelier'},
@@ -792,13 +803,15 @@ const SC={
  },
  maz_noor:{
  img:IMG.maz,title:'Mazagran — Le sac de Noor',text:()=>`
-  <p>Le sac de Noor est coincé derrière un banc soudé. L’eau goutte des bâches avec un rythme patient.</p>
-  <p>Tu peux forcer le métal ou descendre par la cave pour ressortir discrètement.</p>`,
+  <p>Le sac de Noor est coincé derrière un banc soudé. Les sangles collées à la rouille cèdent par à-coups tandis que l’eau goutte des bâches avec un rythme patient.</p>
+  <p>Tu peux forcer le métal, t’aider de ton matériel ou descendre par la cave pour ressortir discrètement.</p>`,
   choices:[
     {label:'Forcer le banc',hint:'SOM/Mécanique (12) — libérer le sac (échec : +1 Blessure)',test:{stat:'SOM',skill:'Mécanique',dd:12,
       ok:s=>{s.tags.add('Noor_Sac');s.objective='Ramener le sac à Noor sur la Place du Pont.';addObj('Sac de Noor récupéré.');},ko:s=>{s.hp=Math.max(0,s.hp-1);log('Tu t’écorches sur le métal. +1 Blessure.')}}},
     {label:'Passer par la cave',hint:'CIN/Furtivité (10) — ressortir sans alerter',test:{stat:'CIN',skill:'Furtivité',dd:10,
       ok:s=>{s.tags.add('Sortie_Discrète');log('Personne ne t’a vu.');},ko:s=>{log('Lampe qui claque. Pas de dégâts.')}}},
+    {label:'Découper les sangles au cutter',hint:'Utiliser ton outil pour libérer le sac sans bruit',when:()=>hasItem('Cutter')&&!ST.tags.has('Noor_Sac'),immediate:s=>{s.tags.add('Noor_Sac');s.objective='Ramener le sac à Noor sur la Place du Pont.';addObj('Le cutter entaille les sangles : sac de Noor libéré.');log('Le cutter grignote la rouille.');},go:'place_return'},
+    {label:'Faire levier avec le tournevis isolé',hint:'Exploiter ton tournevis pour dégager le banc',when:()=>hasItem('Tournevis isolé')&&!ST.tags.has('Noor_Sac'),immediate:s=>{s.tags.add('Noor_Sac');s.tags.add('Sortie_Discrète');s.objective='Ramener le sac à Noor sur la Place du Pont.';addObj('Le tournevis isolé fait céder le banc sans déclencher d’alarme.');},go:'place_return'},
     {label:'Filer aux Berges',hint:'Rejoindre les darses sans perdre de temps',go:'ber_entry'},
     {label:'Investir l’atelier voisin',hint:'Tenter un détour social ou technique',go:'maz_atelier'},
     {label:'Retourner à la Place du Pont',hint:'Remettre le sac ou chercher du soutien',go:'place_return'}
@@ -806,9 +819,10 @@ const SC={
  },
  maz_milo:{
  img:IMG.maz,title:'Mazagran — Le coffret de Milo',text:()=>`
-  <p>Le coffret frappé du sceau de Milo est sanglé à un crochet. Le plomb est déjà ébréché ; tu évites d’y jeter un œil.</p>`,
+  <p>Le coffret frappé du sceau de Milo est sanglé à un crochet. Des motifs gravés luisent sous la pluie ; le plomb est déjà ébréché et un code y est poinçonné.</p>`,
   choices:[
-    {label:'Détacher le coffret pour Milo',hint:'Prépare le passe au Pont',immediate:s=>{s.tags.add('Coffret_Milo');s.inv.push('Coffret (Milo)');s.objective='Apporter le coffret à Milo pour obtenir le laissez-passer.';addObj('Coffret de Milo sécurisé.');}},
+    {label:'Détacher le coffret pour Milo',hint:'Prépare le passe au Pont',immediate:s=>{s.tags.add('Coffret_Milo');gainItem('Coffret (Milo)');s.objective='Apporter le coffret à Milo pour obtenir le laissez-passer.';addObj('Coffret de Milo sécurisé.');}},
+    {label:'Inspecter le coffret à la lampe plate',hint:'Révéler le code gravé (sans l’ouvrir)',when:()=>hasItem('Lampe plate')&&!ST.tags.has('Milo_Code'),immediate:s=>{s.tags.add('Milo_Code');s.objective='Utiliser le code de Milo pour traverser le Pont sans montrer le coffret.';addObj('Le faisceau révèle le code du coffret de Milo.');log('La lampe rase les motifs et révèle des chiffres cachés.');},go:'maz_milo'},
     {label:'Prendre la cave vers les Berges',hint:'Continuer vers la trappe technique',go:'ber_entry'},
     {label:'Se glisser vers l’atelier latéral',hint:'Approcher les ouvriers en douce',go:'maz_atelier'},
     {label:'Retourner vers la Place du Pont',hint:'Négocier le laissez-passer avec Milo',go:'place_return'}
@@ -825,26 +839,39 @@ const SC={
       ko:s=>{s.stress=Math.min(5,s.stress+1);log('On te jauge froidement. +1 Stress.');}
     },goOK:'maz_atelier',goKO:'maz_atelier'},
     {label:'Forcer le casier technique',hint:'CIN/Furtivité (10) — récupérer un badge',when:()=>!ST.tags.has('BadgeTech'),test:{stat:'CIN',skill:'Furtivité',dd:10,
-      ok:s=>{if(!s.inv.includes('Badge maintenance'))s.inv.push('Badge maintenance');s.tags.add('BadgeTech');s.objective='Utiliser le badge pour traverser les contrôles du Pont.';addObj('Badge de maintenance subtilisé.');},
+      ok:s=>{gainItem('Badge maintenance');s.tags.add('BadgeTech');s.objective='Utiliser le badge pour traverser les contrôles du Pont.';addObj('Badge de maintenance subtilisé.');},
       ko:s=>{s.stress=Math.min(5,s.stress+1);log('Un crochet grince. +1 Stress.');}
     },goOK:'maz_atelier',goKO:'maz_atelier'},
     {label:'Calibrer leur génératrice',hint:'NEU/Mécanique (10) — stabiliser la nacelle',when:()=>!ST.tags.has('Berges_Stable'),test:{stat:'NEU',skill:'Mécanique',dd:10,
       ok:s=>{s.tags.add('Berges_Stable');s.objective='Descendre par la nacelle stabilisée vers les Berges.';addObj('La génératrice cale la nacelle : accès plus stable.');},
       ko:s=>{s.hp=Math.max(0,s.hp-1);log('Courant récalcitrant. +1 Blessure.');}
     },goOK:'maz_atelier',goKO:'maz_atelier'},
+    {label:'Sangler la nacelle avec ton ruban textile',hint:'Mettre ton matériel au service de l’atelier',when:()=>hasItem('Ruban textile')&&!ST.tags.has('Berges_Stable'),immediate:s=>{s.tags.add('Berges_Stable');s.objective='Descendre par la nacelle stabilisée vers les Berges.';addObj('Ton ruban textile verrouille les attaches de la nacelle.');},go:'maz_atelier'},
     {label:'Retourner à la cour de Mazagran',hint:'Revenir vers les autres pistes',go:'maz_common'},
     {label:'Descendre vers les Berges',hint:'Suivre la voie préparée',go:'ber_entry'}
   ]
  },
  ber_entry:{
- img:IMG.ber,title:'Berges — Darses',text:()=>`
-  <p>La vase masque une trappe d’entretien. À chaque contact, le métal grince et vibre.</p>`,
+ img:IMG.ber,title:'Berges — Darses',text:()=>{
+  const hints=[];
+  if(ST.tags.has('Feuillet_Map')){hints.push('Les repères UV du feuillet scintillent sur un capot presque noyé.');}
+  if(hasItem('Aimant-alu')){hints.push('Ton aimant-alu pulse doucement lorsque tu le rapproches du loquet.');}
+  const extra=hints.length?`<p>${hints.join(' ')}</p>`:'';
+  return `
+  <p>La vase masque une trappe d’entretien. À chaque contact, le métal grince et vibre.</p>${extra}`;
+ },
   choices:()=>{
     const arr=[
       {label:'Décrocher la trappe technique',hint:'NEU/Cryptanalyse (10) — ouvrir l’accès vers T1',test:{stat:'NEU',skill:'Cryptanalyse',dd:10,
         ok:s=>{s.tags.add('Acces_Tech');s.objective='Descendre vers T1 par la trappe technique.';addObj('Trappe vers T1 ouverte.');},ko:s=>{log('Contacts oxydés : il faudra insister.')}}},
       {label:'Remonter vers le Pont',hint:'Avec le coffret de Milo : passe-droit assuré',go:'pon_pass'}
     ];
+    if(ST.tags.has('Feuillet_Map')&&!ST.tags.has('T1_Grille')){
+      arr.push({label:'Suivre les repères du feuillet-mica',hint:'Utiliser la cartographie secrète de Noor',immediate:s=>{s.tags.add('Pont_Souterrain');s.tags.add('T1_Grille');s.objective='Atteindre T1 via la gaine repérée sur le feuillet.';addObj('Le feuillet révèle une gaine intacte vers T1.');log('Les repères UV scintillent : un passage s’ouvre.');},go:'pon_shadow'});
+    }
+    if(hasItem('Aimant-alu')&&!ST.tags.has('Acces_Tech')){
+      arr.push({label:'Soulever la trappe avec ton aimant-alu',hint:'Déverrouiller en silence grâce à ton outil',immediate:s=>{s.tags.add('Acces_Tech');s.objective='Descendre vers T1 par la trappe technique.';addObj('Aimant-alu décroche les loquets de la trappe.');log('L’aimant attire les goupilles : la trappe bascule.');},go:'t1_overlook'});
+    }
     if(ST.tags.has('Atelier_Allie')&&ST.tags.has('Berges_Stable')){
       arr.push({label:'Appeler la nacelle des ouvriers',hint:'Voie technique sécurisée',immediate:s=>{s.tags.add('Acces_Tech');s.tags.add('T1_Soutien');s.objective='Suivre la nacelle stabilisée jusqu’au périmètre de T1.';addObj('La nacelle de Mazagran t’abaisse vers la sous-station.');},go:'t1_overlook'});
     }
@@ -865,14 +892,15 @@ const SC={
       ok:s=>{s.tags.add('Pont_Escorte');s.objective='Traverser le Pont escorté par la patrouille.';addObj('La patrouille fluviale t’offre un passage encadré.');},ko:s=>{s.stress=Math.min(5,s.stress+1);log('On te renvoie vers la vase. +1 Stress.');}},goOK:'ber_entry',goKO:'ber_patrouille'},
     {label:'Suivre la patrouille à distance',hint:'CIN/Furtivité (11) — repérer la contre-voie',test:{stat:'CIN',skill:'Furtivité',dd:11,
       ok:s=>{s.tags.add('Pont_Souterrain');s.objective='Passer sous le pont par la contre-voie.';addObj('Itinéraire sous le tablier repéré.');},ko:s=>{s.stress=Math.min(5,s.stress+1);log('Un projecteur t’accroche. +1 Stress.');}},goOK:'pon_shadow',goKO:'ber_patrouille'},
+    {label:'Allumer une flamme de détresse',hint:'Utiliser ton briquet pour détourner la patrouille',when:()=>hasItem('Briquet')&&!ST.tags.has('Pont_Distrait'),immediate:s=>{s.tags.add('Pont_Distrait');s.objective='Profiter de la confusion pour franchir le Pont.';addObj('Une flamme brève attire la patrouille vers la vase.');log('Le briquet déclenche une flamme brève : la patrouille se disperse.');},go:'ber_entry'},
     {label:'Saboter le relais de détection',hint:'NEU/Cryptanalyse (11) — détourner les capteurs',test:{stat:'NEU',skill:'Cryptanalyse',dd:11,
       ok:s=>{s.tags.add('Pont_Distrait');s.objective='Profiter de la confusion pour franchir le Pont.';addObj('Les capteurs du Pont partent en boucle.');},ko:s=>{s.stress=Math.min(5,s.stress+1);log('Les alarmes grincent. +1 Stress.');}},goOK:'ber_entry',goKO:'ber_patrouille'},
     {label:'Revenir vers les darses',hint:'Changer de stratégie',go:'ber_entry'}
   ]
  },
  pon_pass:{
-  img:IMG.pon,title:'Pont de la Guill’ — Passage',text:()=>`
-  <p>Deux guetteurs s’abritent sous le pont. Ils filtrent les passages et attendent un signe convaincant.</p>`,
+ img:IMG.pon,title:'Pont de la Guill’ — Passage',text:()=>`
+  <p>Deux guetteurs s’abritent sous le pont. Leurs badges grésillent et ils attendent un signe convaincant pour laisser passer quiconque vers T1.</p>`,
   choices:()=>{
     const a=[];
     if(ST.tags.has('Milo_Pass')){
@@ -885,6 +913,9 @@ const SC={
     }
     if(ST.tags.has('Pont_Escorte')){
       a.push({label:'Suivre l’escorte jusqu’à T1',hint:'Route sociale sécurisée',immediate:s=>{s.objective='Laisser l’escorte te mener au périmètre de T1.';},go:'t1_entry'});
+    }
+    if(ST.tags.has('Milo_Code')&&!ST.tags.has('Milo_Pass')&&!ST.tags.has('Pont_Escorte')){
+      a.push({label:'Énoncer le code gravé du coffret',hint:'Convaincre les guetteurs sans montrer de preuve',immediate:s=>{s.objective='Traverser le Pont et atteindre T1.';log('Le code de Milo ouvre la voie : les guetteurs te laissent filer.');},go:'t1_entry'});
     }
     if(ST.tags.has('Collectif_Dossier')){
       a.push({label:'Révéler le planning volé',hint:'Mettre la pression sur les guetteurs',immediate:s=>{s.tags.delete('Collectif_Dossier');s.tags.add('Pont_Distrait');addObj('Les guetteurs lâchent du lest face aux preuves.');},go:'pon_pass'});
@@ -922,6 +953,7 @@ const SC={
     {label:'Pirater le relais de surveillance',hint:'NEU/Cryptanalyse (11) — déclencher une boucle',test:{stat:'NEU',skill:'Cryptanalyse',dd:11,
       ok:s=>{s.tags.add('Pont_Distrait');addObj('Les capteurs du pont se remettent à zéro dans un grésillement.');},
       ko:s=>{s.stress=Math.min(5,s.stress+1);log('Le relais claque et t’oblige à reculer. +1 Stress.');}},goOK:'pon_pass',goKO:'pon_shadow'},
+    {label:'Allumer une flamme rassurante',hint:'Utiliser ton briquet pour faire baisser la pression (stress -1)',when:()=>hasItem('Briquet')&&!ST.tags.has('Briquet_Calm')&&ST.stress>0,immediate:s=>{s.stress=Math.max(0,s.stress-1);s.tags.add('Briquet_Calm');log('La flamme vacille mais t’apaise. Stress -1.');},go:'pon_shadow'},
     {label:'Revenir vers les Berges',hint:'Retenter depuis les darses',go:'ber_entry'},
     {label:'Remonter vers la Place',hint:'Reprendre son souffle sous l’auvent',go:'place_return'}
   ]
@@ -936,6 +968,15 @@ const SC={
       {label:'Se glisser par la grille',hint:'CIN/Furtivité (10) — infiltration par le bas',test:{stat:'CIN',skill:'Furtivité',dd:10,
         ok:s=>{s.tags.add('T1_Grille');s.objective='Stabiliser le cœur de T1.';addObj('Tu t’infiltres par la grille.');},ko:s=>{log('Une vis tinte. Tu attends.');}}}
     ];
+    if(hasItem('Tournevis isolé')&&!ST.tags.has('T1_Grille')){
+      arr.push({label:'Démonter le panneau latéral',hint:'Utiliser ton tournevis pour créer un accès discret',immediate:s=>{s.tags.add('T1_Grille');s.tags.add('Acces_Tech');s.objective='Glisser vers le cœur de T1 par le panneau démonté.';addObj('Panneau latéral démonté grâce au tournevis isolé.');},go:'t1_overlook'});
+    }
+    if(ST.tags.has('Milo_Code')&&!ST.tags.has('T1_Ouverte')){
+      arr.push({label:'Projeter le motif relevé sur la serrure',hint:'NEU/Déduction (9) — exploiter les codes de Milo',test:{stat:'NEU',skill:'Déduction',dd:9,
+        ok:s=>{s.tags.add('T1_Ouverte');s.objective='Stabiliser le cœur de T1.';addObj('Le motif gravé synchronise la serrure de T1.');},
+        ko:s=>{s.stress=Math.min(5,s.stress+1);log('Le motif rebondit sans effet. +1 Stress.');}
+      },goOK:'t1_entry',goKO:'t1_entry'});
+    }
     if(ST.tags.has('Noor_Trust')){
       arr.push({label:'Noor entrouvre la porte',hint:'Voie sociale depuis les caves',immediate:s=>{s.objective='Stabiliser le cœur de T1.';addObj('Noor te fait entrer par la cave.');}});
     }
@@ -971,14 +1012,44 @@ const SC={
  t1_core:{
   img:IMG.t1,title:'Sous-station T1 — Cœur',text:()=>`
   <p>Le cœur de T1 vibre. Trois leviers bricolés clignotent : <b>Contournement</b>, <b>Relance</b>, <b>Trame douce</b>. Chaque option a son prix.</p>`,
-  choices:[
-    {label:'Contournement — gagner du temps',hint:'SOM/Mécanique (10) — détourner les flux (+1 Flux)',test:{stat:'SOM',skill:'Mécanique',dd:10,
-      ok:s=>{s.flux=Math.max(0,s.flux+1);s.objective='Quitter la zone avant la prochaine alerte.';addObj('Contournement posé : la nuit tiendra un peu plus.');clearEndingTags();markEndingApproach();s.tags.add('End_Contournement');},ko:s=>{s.hp=Math.max(0,s.hp-1);log('Coup de jus. +1 Blessure.')}} ,goOK:()=>pickEnding('cont'),goKO:'ep_silent'},
-    {label:'Relance — plus risqué',hint:'NEU/Déduction (12) — redémarrage bruyant',test:{stat:'NEU',skill:'Déduction',dd:12,
-      ok:s=>{s.tags.add('Relance');addObj('Relance réussie : T1 repart en claquant.');clearEndingTags();markEndingApproach();s.tags.add('End_Noise');},ko:s=>{s.stress=Math.min(5,s.stress+1);log('Tu recules. +1 Stress.')}} ,goOK:()=>pickEnding('noise'),goKO:'ep_silent'},
-    {label:'Trame douce — protéger les souvenirs',hint:'VOL/Empathie (12) + ✦ — apaiser la Sourdine',test:{stat:'VOL',skill:'Empathie',dd:12,needsFrag:true,
-      ok:s=>{s.tags.add('Trame_Douce');s.frag=Math.max(0,s.frag-1);addObj('Voile tiré : les mémoires restent en place.');clearEndingTags();markEndingApproach();s.tags.add('End_Soft');},ko:s=>{log('Tu n’oses pas. Rien ne casse.')}} ,goOK:()=>pickEnding('soft'),goKO:'ep_silent'}
-  ]
+  choices:()=>{
+    const arr=[];
+    if(hasItem('Gants usés')&&!ST.tags.has('Leviers_Prepares')){
+      arr.push({label:'Enfiler tes gants sur les leviers',hint:'Préparer les commandes contre les arcs',immediate:s=>{s.tags.add('Leviers_Prepares');addObj('Les leviers sont isolés par tes gants usés.');log('Tu glisses tes gants usés sur les leviers : l’arc sera amorti.');},go:'t1_core'});
+    }
+    if(hasItem('Ruban textile')&&!ST.tags.has('Leviers_Prepares')){
+      arr.push({label:'Enrubanner les câbles avec ton ruban',hint:'Renforcer l’isolation avant d’agir',immediate:s=>{s.tags.add('Leviers_Prepares');addObj('Le ruban textile amortit les arcs autour des leviers.');log('Tu bandes les leviers de ruban textile.');},go:'t1_core'});
+    }
+    arr.push({label:'Contournement — gagner du temps',hint:'SOM/Mécanique (10) — détourner les flux (+1 Flux)',test:{stat:'SOM',skill:'Mécanique',dd:10,
+      ok:s=>{s.flux=Math.max(0,s.flux+1);s.objective='Quitter la zone avant la prochaine alerte.';addObj('Contournement posé : la nuit tiendra un peu plus.');clearEndingTags();markEndingApproach();s.tags.add('End_Contournement');},
+      ko:s=>{
+        if(s.tags.has('Leviers_Prepares')){
+          s.tags.delete('Leviers_Prepares');
+          log('La protection improvisée brûle mais tu restes indemne.');
+        }else{
+          s.hp=Math.max(0,s.hp-1);
+          log('Coup de jus. +1 Blessure.');
+        }
+      }
+    },goOK:()=>pickEnding('cont'),goKO:'ep_silent'});
+    arr.push({label:'Relance — plus risqué',hint:'NEU/Déduction (12) — redémarrage bruyant',test:{stat:'NEU',skill:'Déduction',dd:12,
+      ok:s=>{s.tags.add('Relance');addObj('Relance réussie : T1 repart en claquant.');clearEndingTags();markEndingApproach();s.tags.add('End_Noise');},
+      ko:s=>{
+        if(s.tags.has('Leviers_Prepares')){
+          s.tags.delete('Leviers_Prepares');
+          log('Le ruban fume mais tu restes concentré·e.');
+        }else{
+          s.stress=Math.min(5,s.stress+1);
+          log('Tu recules. +1 Stress.');
+        }
+      }
+    },goOK:()=>pickEnding('noise'),goKO:'ep_silent'});
+    arr.push({label:'Trame douce — protéger les souvenirs',hint:'VOL/Empathie (12) + ✦ — apaiser la Sourdine',test:{stat:'VOL',skill:'Empathie',dd:12,needsFrag:true,
+      ok:s=>{s.tags.add('Trame_Douce');s.frag=Math.max(0,s.frag-1);addObj('Voile tiré : les mémoires restent en place.');clearEndingTags();markEndingApproach();s.tags.add('End_Soft');},
+      ko:s=>{log('Tu n’oses pas. Rien ne casse.');}
+    },goOK:()=>pickEnding('soft'),goKO:'ep_silent'});
+    return arr;
+  }
  },
  ep_cont:{img:IMG.t1,title:'Épilogue — Contournement',text:()=>`
   <p>Le quartier respire encore. Ce n’est pas brillant, mais tu as gagné quelques heures.</p>`,choices:[{label:'Recommencer (retour Prologue)',go:'prologue'}]},


### PR DESCRIPTION
## Summary
- enrich prologue and key Guillotière scenes with additional descriptive context and dynamic hints
- add helper utilities and multiple item-driven branches for inventory gear across Mazagran, les Berges et le Pont
- allow preparing T1’s leviers with carried tools so failures consume protections instead of causing direct harm

## Testing
- no automated tests (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cfc798a50083318680cf59e45a5132