### PR TITLE
feat: mobile header control

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,131 +6,369 @@
 <title>TRAME DOUCE — Guillotière (v6.4)</title>
 <style>
 :root{
-  --bg:#0b0e15; --p:#12182a; --p2:#0e1423; --ink:#eaf2ff; --mut:#9fb1cf; --line:#1a2438;
-  --a:#9cf6ff; --b:#ffc2e9; --warn:#ffbd73; --bad:#ff6b7a; --good:#78f2bb;
-  --neu:#6ad0ff; --vol:#ff78a8; --som:#ffc76e; --cin:#92ffcc; --sh:0 8px 28px rgba(0,0,0,.35);
-  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --bg:#040607;
+  --bg2:#10131a;
+  --p:rgba(19,22,28,.9);
+  --p2:rgba(13,17,24,.92);
+  --ink:#f7f1e6;
+  --mut:#c5bdb0;
+  --line:rgba(255,195,125,.16);
+  --a:#ffb35e;
+  --b:#65f1dd;
+  --warn:#ffca7d;
+  --bad:#ff6b7a;
+  --good:#8ef2a5;
+  --neu:#79d7ff;
+  --vol:#ff7f96;
+  --som:#ffc76e;
+  --cin:#92ffcc;
+  --oxide:#f2754d;
+  --glow:#77f4ff;
+  --sh:0 14px 44px rgba(0,0,0,.55);
+  --safe-bottom:env(safe-area-inset-bottom,0px);
 }
-*{box-sizing:border-box} html,body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;line-height:1.55}
+*{box-sizing:border-box}
+html,body{
+  margin:0;
+  color:var(--ink);
+  font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;
+  line-height:1.55;
+  background:var(--bg);
+  min-height:100%;
+}
+body{
+  position:relative;
+  min-height:100vh;
+  background:
+    radial-gradient(circle at 18% 12%,rgba(119,244,255,.08),transparent 55%),
+    radial-gradient(circle at 80% 0,rgba(242,117,77,.15),transparent 50%),
+    linear-gradient(160deg,var(--bg),var(--bg2) 68%);
+  overflow-x:hidden;
+}
+body::before,body::after{
+  content:"";
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  z-index:-1;
+}
+body::before{
+  background:radial-gradient(circle at 20% 80%,rgba(255,179,94,.08) 0,transparent 60%),
+    radial-gradient(circle at 88% 40%,rgba(101,241,221,.08) 0,transparent 55%);
+}
+body::after{
+  opacity:.22;
+  mix-blend-mode:screen;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Crect width='1' height='1' fill='%23ffffff'/%3E%3C/svg%3E");
+  background-size:160px;
+}
+::selection{background:rgba(242,117,77,.35);color:var(--ink)}
+*{scrollbar-color:rgba(255,179,94,.5) rgba(12,16,22,.9)}
+::-webkit-scrollbar{width:10px;height:10px}
+::-webkit-scrollbar-track{background:rgba(12,16,22,.85)}
+::-webkit-scrollbar-thumb{background:linear-gradient(180deg,rgba(255,179,94,.8),rgba(101,241,221,.8));border-radius:999px}
+@keyframes panelIn{from{opacity:0;transform:translateY(16px);}to{opacity:1;transform:translateY(0);}}
+@keyframes ticker{0%{transform:translateX(0);}100%{transform:translateX(-100%);}}
+@keyframes glowDrift{0%{transform:scale(1) translate3d(0,0,0);}100%{transform:scale(1.08) translate3d(8px,-12px,0);}}
+@keyframes choiceRise{0%{opacity:0;transform:translateY(18px);}100%{opacity:1;transform:translateY(0);}}
+@keyframes glowPulse{0%{box-shadow:0 0 0 rgba(255,179,94,.0);}50%{box-shadow:0 0 30px rgba(255,179,94,.25);}100%{box-shadow:0 0 0 rgba(255,179,94,.0);}}
+@keyframes headerSweep{0%{transform:translateX(-40px);}50%{transform:translateX(36px);}100%{transform:translateX(-40px);}}
+@keyframes signalSweep{0%{background-position:0 0,0 0,0 0;}100%{background-position:180px -120px,-140px 160px,220px 180px;}}
 a{color:var(--a)}
-.header{position:sticky;top:0;z-index:20;display:flex;flex-direction:column;gap:12px;padding:calc(10px + env(safe-area-inset-top,0px)) 12px 10px;border-bottom:1px solid var(--line);
-  background:linear-gradient(180deg,rgba(15,20,34,.92),rgba(15,20,34,.65));backdrop-filter:blur(8px)}
-.headerTop{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.header{
+  position:sticky;
+  top:0;
+  z-index:20;
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  padding:calc(12px + env(safe-area-inset-top,0px)) 14px 14px;
+  border-bottom:1px solid rgba(255,179,94,.22);
+  background:linear-gradient(180deg,rgba(9,11,15,.96),rgba(10,13,18,.72));
+  backdrop-filter:blur(14px);
+  box-shadow:0 18px 42px rgba(0,0,0,.45);
+  transition:box-shadow .3s ease,border-color .3s ease,transform .35s ease;
+  isolation:isolate;
+  overflow:hidden;
+  transform:translateZ(0);
+}
+.header::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at 12% 20%,rgba(119,244,255,.12),transparent 55%);
+  opacity:.6;
+  pointer-events:none;
+  z-index:-1;
+}
+.header::after{
+  content:"";
+  position:absolute;
+  left:-20%;
+  right:-20%;
+  bottom:-32px;
+  height:64px;
+  background:linear-gradient(115deg,rgba(255,179,94,.2),rgba(101,241,221,.08));
+  opacity:.45;
+  filter:blur(18px);
+  animation:headerSweep 18s linear infinite;
+  pointer-events:none;
+  z-index:-1;
+}
+.header.header-hidden{
+  transform:translateY(calc(-100% - 16px));
+  box-shadow:0 18px 42px rgba(0,0,0,0);
+}
+.header.collapsed .headerCollapseBtn .collapseIcon{transform:rotate(180deg);}
+.headerMeta{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  transition:max-height .35s ease,opacity .35s ease,filter .35s ease,transform .35s ease;
+  max-height:520px;
+  overflow:hidden;
+}
+.header.collapsed .headerMeta{
+  max-height:0;
+  opacity:0;
+  filter:blur(3px);
+  transform:translateY(-8px);
+  pointer-events:none;
+}
+.headerCollapseBtn{
+  display:none;
+  align-items:center;
+  gap:8px;
+  margin-left:auto;
+  padding:8px 14px;
+  border-radius:999px;
+  border:1px solid rgba(255,179,94,.26);
+  background:linear-gradient(180deg,rgba(18,23,31,.92),rgba(9,11,16,.88));
+  color:var(--mut);
+  font-size:11px;
+  letter-spacing:1px;
+  text-transform:uppercase;
+  cursor:pointer;
+  box-shadow:0 12px 28px rgba(0,0,0,.4);
+  transition:transform .2s ease,box-shadow .2s ease,background .3s ease;
+}
+.headerCollapseBtn .collapseLabel{font-weight:600;letter-spacing:.9px;}
+.headerCollapseBtn .collapseIcon{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:18px;
+  height:18px;
+  border-radius:50%;
+  background:rgba(255,179,94,.12);
+  color:var(--a);
+  transition:transform .3s ease,background .3s ease;
+}
+.headerCollapseBtn:hover{
+  transform:translateY(-1px);
+  box-shadow:0 16px 32px rgba(0,0,0,.45);
+}
+.headerCollapseBtn:hover .collapseIcon{background:rgba(255,179,94,.22);}
+.headerCollapseBtn:focus-visible{outline:2px solid var(--glow);outline-offset:3px;}
+.headerTop{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
 .header .row{display:flex;gap:8px;flex-wrap:wrap}
-.header .title{font-weight:800;letter-spacing:.5px;flex:1}
-.headerControls{display:flex;align-items:center;gap:8px;margin-left:auto}
+.header .title{font-weight:800;letter-spacing:.6px;flex:1;display:flex;align-items:center;gap:10px;text-transform:uppercase;text-shadow:0 0 18px rgba(101,241,221,.3)}
+.header .title span{letter-spacing:1.2px}
+#loc{color:var(--glow)}
+.headerControls{display:flex;align-items:center;gap:8px;margin-left:auto;flex-wrap:wrap}
 .headerBadges{gap:8px;flex-wrap:wrap;width:100%}
-.viewBadge{background:rgba(255,255,255,.04);border-style:dashed;color:var(--ink);font-weight:600}
-.btn.ghost{background:rgba(13,20,33,.6);border-style:dashed;color:var(--ink)}
-.iconBtn{padding:0 12px;height:38px;border:1px solid #2a3a58;background:linear-gradient(180deg,#161f31,#0f1624);border-radius:12px;color:var(--ink);font-size:20px;cursor:pointer;display:grid;place-items:center;font-weight:700;min-width:38px}
+.headerLore{margin:2px 0 4px 0;color:var(--mut);font-size:13px;max-width:620px;line-height:1.6}
+.headerTicker{position:relative;overflow:hidden;border:1px solid rgba(255,179,94,.24);border-radius:10px;padding:6px 0;background:rgba(12,16,22,.7);box-shadow:inset 0 0 0 1px rgba(119,244,255,.08);margin-top:4px}
+.headerTicker::before,.headerTicker::after{content:"";position:absolute;top:0;bottom:0;width:32px;pointer-events:none}
+.headerTicker::before{left:0;background:linear-gradient(90deg,rgba(12,16,22,.9),transparent)}
+.headerTicker::after{right:0;background:linear-gradient(270deg,rgba(12,16,22,.9),transparent)}
+.headerTicker span{display:inline-block;padding-left:100%;white-space:nowrap;font-size:12px;letter-spacing:.6px;color:var(--mut);animation:ticker 22s linear infinite}
+.viewBadge{background:rgba(255,179,94,.12);border-style:dashed;color:var(--ink);font-weight:600}
+.btn.ghost{background:rgba(16,21,29,.7);border-style:dashed;color:var(--ink)}
+.iconBtn{padding:0 12px;height:38px;border:1px solid rgba(255,179,94,.24);background:linear-gradient(180deg,rgba(19,24,31,.9),rgba(10,12,18,.9));border-radius:12px;color:var(--ink);font-size:20px;cursor:pointer;display:grid;place-items:center;font-weight:700;min-width:38px;box-shadow:0 8px 18px rgba(0,0,0,.35);transition:transform .2s ease,box-shadow .2s ease}
+.iconBtn:hover{transform:translateY(-1px);box-shadow:0 10px 26px rgba(0,0,0,.4)}
 .menuWrap{position:relative}
 .menuWrap.open .iconBtn{outline:2px solid var(--a)}
-.navMenu{display:none;position:absolute;right:0;top:calc(100% + 8px);background:var(--p2);border:1px solid var(--line);border-radius:12px;padding:8px;min-width:180px;box-shadow:var(--sh);flex-direction:column;gap:6px}
-.menuWrap.open .navMenu{display:flex}
+.navMenu{
+  display:flex;
+  position:absolute;
+  right:0;
+  top:calc(100% + 10px);
+  background:var(--p2);
+  border:1px solid rgba(255,179,94,.22);
+  border-radius:14px;
+  padding:10px;
+  min-width:190px;
+  box-shadow:0 18px 44px rgba(0,0,0,.6);
+  flex-direction:column;
+  gap:6px;
+  opacity:0;
+  transform:translateY(-6px) scale(.95);
+  pointer-events:none;
+  transition:opacity .18s ease,transform .22s ease;
+}
+.menuWrap.open .navMenu{
+  opacity:1;
+  transform:translateY(0) scale(1);
+  pointer-events:auto;
+}
 .navMenu .tabbtn{width:100%;text-align:left;justify-content:flex-start}
-.tabbtn,.btn{padding:10px 12px;border:1px solid #2a3a58;background:linear-gradient(180deg,#141f33,#223355);border-radius:12px;color:var(--ink);cursor:pointer;font-weight:700;display:inline-flex;align-items:center;justify-content:center;gap:6px;text-align:center}
-.tabbtn[aria-pressed="true"],.btn.primary{outline:2px solid var(--a)}
-.badge{display:inline-flex;align-items:center;gap:6px;border:1px solid #2a3a58;background:var(--p2);color:var(--mut);padding:2px 8px;border-radius:999px;font-size:12px}
+.tabbtn,.btn{padding:11px 14px;border:1px solid rgba(255,179,94,.22);background:linear-gradient(180deg,rgba(18,22,30,.95),rgba(12,15,21,.88));border-radius:12px;color:var(--ink);cursor:pointer;font-weight:700;display:inline-flex;align-items:center;justify-content:center;gap:6px;text-align:center;transition:transform .2s ease,box-shadow .2s ease,outline .2s ease}
+.tabbtn:hover,.btn:hover{transform:translateY(-2px);box-shadow:0 12px 28px rgba(0,0,0,.45)}
+.tabbtn:active,.btn:active{transform:translateY(0)}
+.tabbtn[aria-pressed="true"],.btn.primary{outline:2px solid var(--a);box-shadow:0 0 25px rgba(255,179,94,.3)}
+.tabbtn:focus-visible,.btn:focus-visible{outline:2px solid var(--glow);outline-offset:2px}
+.badge{display:inline-flex;align-items:center;gap:6px;border:1px solid rgba(255,179,94,.2);background:rgba(14,18,24,.7);color:var(--mut);padding:4px 10px;border-radius:999px;font-size:12px;box-shadow:inset 0 0 0 1px rgba(119,244,255,.08);backdrop-filter:blur(8px)}
 .icon{width:16px;height:16px;opacity:.9}
-.grid{display:grid;gap:16px;grid-template-columns:minmax(280px,320px) minmax(0,1fr) minmax(300px,360px);max-width:1280px;margin:auto;padding:16px;padding-bottom:calc(16px + var(--safe-bottom))}
-.col{background:var(--p);border:1px solid var(--line);border-radius:14px;box-shadow:var(--sh);overflow:hidden;display:flex;flex-direction:column;gap:16px}
-.pad{padding:16px;display:flex;flex-direction:column;gap:12px}
+.grid{display:grid;gap:20px;grid-template-columns:minmax(280px,320px) minmax(0,1fr) minmax(300px,360px);max-width:1280px;margin:auto;padding:22px 22px calc(22px + var(--safe-bottom));animation:panelIn .6s ease both;position:relative;z-index:1}
+.grid::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:
+    radial-gradient(circle at 18% -10%,rgba(255,179,94,.18),transparent 55%),
+    radial-gradient(circle at 92% 120%,rgba(101,241,221,.14),transparent 60%),
+    repeating-linear-gradient(125deg,rgba(255,179,94,.04) 0 6px,transparent 6px 24px);
+  mix-blend-mode:screen;
+  opacity:.32;
+  pointer-events:none;
+  border-radius:28px;
+  filter:blur(0);
+  animation:signalSweep 28s linear infinite;
+  z-index:-1;
+}
+.col{position:relative;background:var(--p);border:1px solid rgba(255,179,94,.18);border-radius:16px;box-shadow:var(--sh);overflow:hidden;display:flex;flex-direction:column;gap:16px;transition:transform .35s ease,box-shadow .35s ease}
+.col::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at 20% -10%,rgba(119,244,255,.08),transparent 55%),radial-gradient(circle at 90% 120%,rgba(242,117,77,.08),transparent 60%);opacity:.7;pointer-events:none}
+.col:hover{transform:translateY(-4px);box-shadow:0 28px 48px rgba(0,0,0,.55)}
+.col:focus-within{box-shadow:0 28px 48px rgba(0,0,0,.55),0 0 0 2px rgba(119,244,255,.3)}
+.pad{padding:18px;display:flex;flex-direction:column;gap:12px;position:relative}
 .row{display:flex;gap:8px;flex-wrap:wrap}
-.sectionTitle{color:var(--mut);font-size:12px;text-transform:uppercase;margin:0 0 4px;letter-spacing:.8px}
-.sectionIntro{margin:0;color:var(--mut);font-size:13px;line-height:1.5}
+.sectionTitle{color:var(--mut);font-size:12px;text-transform:uppercase;margin:0 0 4px;letter-spacing:1.1px}
+.sectionIntro{margin:0;color:var(--mut);font-size:13px;line-height:1.6}
 .saveActions{display:flex;flex-wrap:wrap;gap:8px}
-.saveActions .btn{flex:1 1 150px;min-width:140px;padding:9px 12px;border-radius:10px;font-size:13px}
-.btn.subtle{background:linear-gradient(180deg,#152033,#1f2d45);border:1px solid #32425f}
+.saveActions .btn{flex:1 1 150px;min-width:140px;padding:10px 14px;border-radius:12px;font-size:13px}
+.btn.subtle{background:linear-gradient(180deg,rgba(22,26,34,.9),rgba(16,20,27,.88));border:1px solid rgba(119,244,255,.18)}
 .btnIcon{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;font-size:14px;opacity:.85}
 .btnLabel{display:inline-flex;align-items:center;justify-content:center;gap:8px}
 /* left */
-.stat{display:grid;grid-template-columns:24px 1fr 24px;align-items:center;background:var(--p2);border:1px solid var(--line);border-radius:10px;padding:6px;min-width:120px}
+.stat{display:grid;grid-template-columns:24px 1fr 24px;align-items:center;background:linear-gradient(135deg,rgba(12,16,22,.9),rgba(24,30,40,.85));border:1px solid rgba(255,179,94,.14);border-radius:12px;padding:8px;min-width:120px;box-shadow:inset 0 0 0 1px rgba(119,244,255,.08)}
 .stat .dot{width:16px;height:16px;border-radius:5px} .stat .name{font-size:11px;color:var(--mut);text-transform:uppercase} .stat .val{font-weight:800;text-align:right}
 .neu .dot{background:var(--neu)} .neu .val{color:var(--neu)} .vol .dot{background:var(--vol)} .vol .val{color:var(--vol)} .som .dot{background:var(--som)} .som .val{color:var(--som)} .cin .dot{background:var(--cin)} .cin .val{color:var(--cin)}
-.resbar{display:flex;gap:8px}.res{flex:1;background:var(--p2);border:1px solid var(--line);border-radius:10px;overflow:hidden}
-.res .lbl{font-size:12px;color:var(--mut);padding:6px 8px;border-bottom:1px solid var(--line)} .meter{height:6px;background:var(--line)}
-.fill{height:6px;background:linear-gradient(90deg,var(--a),var(--b))} .fill.bad{background:linear-gradient(90deg,var(--bad),var(--warn))}
-.inventory{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
-.inventory li{display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:10px;background:var(--p2);border:1px solid var(--line);font-size:13px}
-.inventory-slot{display:inline-flex;align-items:center;justify-content:center;width:32px;height:24px;border-radius:8px;background:rgba(255,255,255,.05);border:1px solid var(--line);font-weight:700;color:var(--mut);font-variant-numeric:tabular-nums}
+.resbar{display:flex;gap:8px}.res{flex:1;background:linear-gradient(135deg,rgba(15,18,24,.85),rgba(22,27,35,.82));border:1px solid rgba(255,179,94,.14);border-radius:12px;overflow:hidden;box-shadow:inset 0 0 0 1px rgba(119,244,255,.06)}
+.res .lbl{font-size:12px;color:var(--mut);padding:6px 8px;border-bottom:1px solid rgba(255,179,94,.14);text-transform:uppercase;letter-spacing:.4px}
+.meter{height:8px;background:rgba(255,179,94,.12)}
+.fill{height:8px;background:linear-gradient(90deg,var(--a),var(--b));transition:width .4s ease}
+.fill.bad{background:linear-gradient(90deg,var(--bad),var(--warn))}
+.inventory{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px}
+.inventory li{display:flex;align-items:center;gap:10px;padding:8px 10px;border-radius:12px;background:rgba(15,20,26,.78);border:1px solid rgba(255,179,94,.12);font-size:13px;box-shadow:inset 0 0 0 1px rgba(119,244,255,.05);transition:transform .2s ease,background .2s ease}
+.inventory li:hover{transform:translateX(4px);background:rgba(18,24,32,.85)}
+.inventory-slot{display:inline-flex;align-items:center;justify-content:center;width:34px;height:26px;border-radius:9px;background:rgba(255,255,255,.04);border:1px solid rgba(255,179,94,.2);font-weight:700;color:var(--mut);font-variant-numeric:tabular-nums;text-shadow:0 0 12px rgba(119,244,255,.25)}
 .inventory-item{flex:1}
 .inventory-empty{justify-content:center;color:var(--mut);font-style:italic}
-.ascii{font-family:Consolas,Menlo,monospace;font-size:12px;background:#0b0f15;border:1px solid var(--line);border-radius:12px;padding:10px;white-space:pre-wrap;color:#b9c7da}
+.ascii{font-family:Consolas,Menlo,monospace;font-size:12px;background:rgba(10,14,19,.8);border:1px solid rgba(255,179,94,.18);border-radius:14px;padding:12px;white-space:pre-wrap;color:#b9c7da;box-shadow:inset 0 0 32px rgba(0,0,0,.55);text-shadow:0 0 8px rgba(101,241,221,.15)}
 /* story */
-.storyImage{position:relative;border-radius:14px;overflow:hidden;border:1px solid var(--line);background:#0a0e13}
-.storyImage img{width:100%;height:240px;object-fit:cover;filter:contrast(1.05) saturate(1.1) brightness(.88)}
+.storyImage{position:relative;border-radius:18px;overflow:hidden;border:1px solid rgba(255,179,94,.18);background:#080b10;box-shadow:0 20px 40px rgba(0,0,0,.55);isolation:isolate}
+.storyImage::before{content:"";position:absolute;inset:0;background:linear-gradient(180deg,rgba(5,6,8,.2),rgba(5,6,8,.75));opacity:.65;mix-blend-mode:multiply;pointer-events:none}
+.storyImage::after{content:"";position:absolute;inset:0;background:radial-gradient(circle at 12% 20%,rgba(255,179,94,.24),transparent 50%),radial-gradient(circle at 80% 80%,rgba(101,241,221,.2),transparent 60%);opacity:.55;pointer-events:none;animation:glowDrift 14s ease-in-out infinite alternate}
+.storyImage img{width:100%;height:240px;object-fit:cover;filter:contrast(1.12) saturate(1.05) brightness(.82);transform:scale(1.02);transition:transform 1.2s ease}
+.storyImage:hover img{transform:scale(1.05)}
 @media (max-width: 900px){
   .storyImage img{height:200px}
-  .header{position:sticky;gap:12px}
+  .header{gap:8px;padding:calc(10px + env(safe-area-inset-top,0px)) 12px 12px}
   .header .title{font-size:18px}
-  .headerTop{align-items:flex-start}
+  .headerTop{align-items:flex-start;gap:10px}
   .headerControls{margin-left:0;width:100%;justify-content:flex-start;flex-wrap:wrap}
   .headerControls .btn,.headerControls .iconBtn{width:auto}
+  .headerCollapseBtn{display:inline-flex;font-size:10px;padding:7px 12px}
+  .headerMeta{gap:8px}
   .headerBadges{width:100%;justify-content:flex-start}
+  .headerLore{font-size:12px}
+  .headerTicker{width:100%}
 }
-.storyImage .legend{position:absolute;left:10px;bottom:10px;background:rgba(10,14,19,.7);padding:6px 8px;border-radius:8px;border:1px solid var(--line);color:var(--mut);font-size:12px}
-.storyBody{background:var(--p2);border:1px solid var(--line);border-radius:14px;padding:18px}
-.choices{display:flex;flex-direction:column;gap:10px;margin-top:10px}
-.choice{position:relative;border:1px solid #2a3a58;background:linear-gradient(180deg,#151e31,#233355);padding:12px;border-radius:12px;cursor:pointer;transition:transform .15s ease,outline .15s ease}
-.choice:hover,.choice:focus-visible{outline:2px solid var(--a)} .choice small{display:block;color:var(--mut)}
-.choice:active{transform:translateY(1px)}
-.choice .tags{position:absolute;right:8px;top:8px;display:flex;gap:6px;flex-wrap:wrap}
-.tag{padding:2px 6px;border-radius:999px;border:1px solid var(--line);font-size:11px;background:rgba(255,255,255,.03)}
+.storyImage .legend{position:absolute;left:12px;bottom:12px;background:rgba(10,13,19,.78);padding:8px 12px;border-radius:10px;border:1px solid rgba(255,179,94,.2);color:var(--mut);font-size:12px;backdrop-filter:blur(8px);text-transform:uppercase;letter-spacing:.6px}
+.storyBody{position:relative;background:linear-gradient(150deg,rgba(13,17,24,.92),rgba(21,26,34,.88));border:1px solid rgba(255,179,94,.16);border-radius:18px;padding:22px;box-shadow:inset 0 0 0 1px rgba(119,244,255,.05)}
+.storyBody::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at 18% 20%,rgba(255,179,94,.08),transparent 50%),radial-gradient(circle at 90% 0,rgba(119,244,255,.08),transparent 55%);opacity:.6;pointer-events:none}
+.storyBody h2{text-transform:uppercase;letter-spacing:1px}
+.storyBody p{color:var(--mut);line-height:1.7}
+.choices{display:flex;flex-direction:column;gap:12px;margin-top:14px}
+.choice{position:relative;border:1px solid rgba(255,179,94,.2);background:linear-gradient(180deg,rgba(17,22,30,.92),rgba(11,14,20,.92));padding:16px;border-radius:14px;cursor:pointer;transition:transform .25s ease,outline .2s ease,box-shadow .25s ease;background-size:200%;box-shadow:0 18px 32px rgba(0,0,0,.35);overflow:hidden;animation:choiceRise .45s ease both}
+.choices .choice:nth-child(1){animation-delay:.05s}
+.choices .choice:nth-child(2){animation-delay:.1s}
+.choices .choice:nth-child(3){animation-delay:.15s}
+.choices .choice:nth-child(4){animation-delay:.2s}
+.choices .choice:nth-child(5){animation-delay:.25s}
+.choice::after{content:"";position:absolute;inset:-40% -10%;background:linear-gradient(120deg,transparent 0,rgba(255,179,94,.12) 45%,rgba(101,241,221,.18) 60%,transparent 80%);opacity:0;transform:translateX(-40%);transition:transform .45s ease,opacity .45s ease;pointer-events:none}
+.choice:hover,.choice:focus-visible{outline:2px solid var(--a);transform:translateY(-3px);box-shadow:0 26px 42px rgba(0,0,0,.45)}
+.choice:hover::after,.choice:focus-visible::after{opacity:.65;transform:translateX(0)}
+.choice small{display:block;color:var(--mut)}
+.choice:active{transform:translateY(-1px)}
+.choice .tags{position:absolute;right:10px;top:10px;display:flex;gap:6px;flex-wrap:wrap}
+.tag{padding:4px 7px;border-radius:999px;border:1px solid rgba(255,179,94,.22);font-size:11px;background:rgba(255,179,94,.08);backdrop-filter:blur(8px);text-transform:uppercase;letter-spacing:.4px}
 .attr-NEU{border-left:4px solid var(--neu)} .attr-VOL{border-left:4px solid var(--vol)} .attr-SOM{border-left:4px solid var(--som)} .attr-CIN{border-left:4px solid var(--cin)}
 /* tests */
-.testPanel{margin-top:12px;border:1px dashed #2a3a58;border-radius:12px;padding:10px 12px;background:rgba(255,255,255,.02)}
+.testPanel{margin-top:14px;border:1px dashed rgba(255,179,94,.3);border-radius:14px;padding:14px 16px;background:rgba(10,13,19,.55);backdrop-filter:blur(8px);box-shadow:inset 0 0 0 1px rgba(119,244,255,.06)}
 .testControls label{flex:1 1 160px}
-.testResult{display:none;margin-top:10px;padding:10px 12px;border-radius:10px;border:1px solid var(--line);background:rgba(255,255,255,.03);font-weight:700}
-.testResult.show{display:block}
-.testResult.success{border-color:var(--good);color:var(--good)}
-.testResult.fail{border-color:var(--bad);color:var(--bad)}
-.btn{padding:10px 12px;border:1px solid #2a3a58;background:linear-gradient(180deg,#151e31,#233355);border-radius:12px;color:var(--ink);cursor:pointer}
-.btn[disabled]{opacity:.4;cursor:not-allowed}
+.testControls input{margin-right:6px}
+.testResult{display:none;margin-top:12px;padding:12px 14px;border-radius:12px;border:1px solid rgba(255,179,94,.2);background:rgba(10,16,23,.65);font-weight:700;box-shadow:inset 0 0 0 1px rgba(119,244,255,.06)}
+.testResult.show{display:block;animation:glowPulse 1.2s ease both}
+.testResult.success{border-color:var(--good);color:var(--good);text-shadow:0 0 12px rgba(142,242,165,.35)}
+.testResult.fail{border-color:var(--bad);color:var(--bad);text-shadow:0 0 12px rgba(255,107,122,.3)}
+.testPanel .small,#testHint{margin-top:8px;color:var(--mut);font-size:13px;line-height:1.6}
+.btn{padding:11px 14px;border:1px solid rgba(255,179,94,.22);background:linear-gradient(180deg,rgba(18,22,30,.95),rgba(12,15,21,.88));border-radius:12px;color:var(--ink);cursor:pointer;position:relative;overflow:hidden}
+.btn.primary{background:linear-gradient(135deg,rgba(255,179,94,.85),rgba(101,241,221,.85));color:#1a0f08;text-shadow:0 0 12px rgba(101,241,221,.35)}
+.btn.primary:hover{box-shadow:0 18px 32px rgba(255,179,94,.3)}
+.btn[disabled]{opacity:.35;cursor:not-allowed;filter:grayscale(.3)}
 /* right */
-.log{height:360px;overflow:auto;background:var(--p2);border:1px solid var(--line);border-radius:12px;padding:8px}
-.log .line{padding:6px 0;border-bottom:1px dashed var(--line);font-size:13px}
-.timeline{height:160px;overflow:auto;background:var(--p2);border:1px solid var(--line);border-radius:12px;padding:8px}
-.timeline .item{margin:4px 0;padding:8px;border-left:3px solid var(--b);background:rgba(255,255,255,.02);border-radius:8px}
-.timeline .when{color:var(--mut);font-size:12px}
+.log{height:360px;overflow:auto;background:rgba(12,17,24,.75);border:1px solid rgba(255,179,94,.16);border-radius:16px;padding:12px;box-shadow:inset 0 0 0 1px rgba(119,244,255,.06)}
+.log .line{padding:8px 0;border-bottom:1px dashed rgba(255,179,94,.18);font-size:13px;color:var(--mut)}
+.log .line:last-child{border-bottom:none}
+.timeline{height:180px;overflow:auto;background:rgba(12,17,24,.75);border:1px solid rgba(255,179,94,.16);border-radius:16px;padding:12px;box-shadow:inset 0 0 0 1px rgba(119,244,255,.06)}
+.timeline .item{margin:6px 0;padding:10px;border-left:3px solid var(--b);background:rgba(255,179,94,.08);border-radius:8px;box-shadow:0 0 0 1px rgba(119,244,255,.06)}
+.timeline .when{color:var(--mut);font-size:12px;letter-spacing:.4px}
 /* dice */
-#diceOverlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:center;justify-content:center;z-index:40}
-.diceWrap{background:var(--p);border:1px solid var(--line);border-radius:14px;padding:16px;min-width:300px;text-align:center}
-.cubes{display:flex;gap:16px;justify-content:center;margin:10px 0 4px 0}
-.cube{width:72px;height:72px;border-radius:12px;background:linear-gradient(180deg,#1b2330,#0b1017);border:1px solid #273243;display:grid;place-items:center;font-size:40px;color:#fff}
-.diceActions{gap:10px;margin-top:12px;justify-content:center;flex-wrap:wrap}
-.diceActions .btn{min-width:120px}
-#diceInfo{margin-top:10px;color:var(--mut);line-height:1.5}
+#diceOverlay{position:fixed;inset:0;background:radial-gradient(circle at 20% 20%,rgba(255,179,94,.12),transparent 65%),rgba(2,3,4,.78);display:none;align-items:center;justify-content:center;z-index:40;backdrop-filter:blur(8px)}
+.diceWrap{background:linear-gradient(150deg,rgba(12,17,24,.94),rgba(10,13,19,.9));border:1px solid rgba(255,179,94,.24);border-radius:18px;padding:20px;min-width:320px;text-align:center;box-shadow:0 28px 52px rgba(0,0,0,.55)}
+.cubes{display:flex;gap:20px;justify-content:center;margin:14px 0 6px 0}
+.cube{width:72px;height:72px;border-radius:14px;background:linear-gradient(180deg,rgba(27,35,45,.95),rgba(8,11,16,.92));border:1px solid rgba(101,241,221,.28);display:grid;place-items:center;font-size:40px;color:#fff;box-shadow:0 12px 28px rgba(0,0,0,.45)}
+.diceActions{gap:12px;margin-top:16px;justify-content:center;flex-wrap:wrap}
+.diceActions .btn{min-width:140px}
+#diceInfo{margin-top:12px;color:var(--mut);line-height:1.6}
 .diceSummary{font-weight:600;color:var(--ink)}
 .diceBreakdown{margin-top:6px;font-size:13px;color:var(--mut)}
 .diceStatus{margin-top:8px;font-weight:700}
 .diceStatus.success{color:var(--good)}
 .diceStatus.fail{color:var(--bad)}
-@media (prefers-reduced-motion: reduce){ .cube{animation:none!important} }
+@media (prefers-reduced-motion: reduce){
+  .cube{animation:none!important}
+  .grid,.choice,.storyImage::after,.headerTicker span,.header::after,.grid::before{animation:none!important}
+  .choice,.col,.btn,.iconBtn,.header,.headerCollapseBtn,.navMenu{transition:none!important}
+}
 .anim{animation:roll 1s ease-in-out infinite}
 @keyframes roll{0%{transform:rotate(0)}33%{transform:rotate(12deg)}66%{transform:rotate(-9deg)}100%{transform:rotate(0)}}
 /* modals */
-.modalScreen{position:fixed;inset:0;background:rgba(10,14,19,.88);display:flex;align-items:center;justify-content:center;z-index:50;padding:24px;overflow-y:auto}
-.modalBox{background:var(--p);border:1px solid var(--line);padding:20px;border-radius:16px;max-width:1000px;width:95%;max-height:calc(100vh - 48px);overflow:auto;box-shadow:var(--sh)}
+.modalScreen{position:fixed;inset:0;background:radial-gradient(circle at 20% 20%,rgba(255,179,94,.1),transparent 65%),rgba(5,6,8,.9);display:flex;align-items:center;justify-content:center;z-index:50;padding:24px;overflow-y:auto;backdrop-filter:blur(8px)}
+.modalBox{background:linear-gradient(150deg,rgba(12,17,24,.95),rgba(10,13,19,.92));border:1px solid rgba(255,179,94,.24);padding:24px;border-radius:20px;max-width:1000px;width:95%;max-height:calc(100vh - 48px);overflow:auto;box-shadow:0 24px 48px rgba(0,0,0,.55)}
 .modalBox h2{margin:0 0 8px 0}
-.introBox{background:linear-gradient(180deg,#111827,#0d131f);border:1px solid rgba(156,246,255,.25)}
+.introBox{background:linear-gradient(180deg,rgba(16,21,29,.95),rgba(12,15,22,.92));border:1px solid rgba(156,246,255,.28);box-shadow:0 18px 36px rgba(0,0,0,.45)}
 .introLead{margin:0 0 12px 0;color:var(--mut);font-size:15px;line-height:1.7}
 .introColumns{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;margin:6px 0 16px 0}
 .introColumns h3{margin:0 0 6px 0;color:var(--ink);font-size:16px;letter-spacing:.5px}
 .introColumns ul{margin:0;padding-left:18px;color:var(--mut);font-size:14px;line-height:1.6}
 .introColumns li{margin:0 0 8px 0}
-.introNote{border:1px solid rgba(156,246,255,.18);background:rgba(156,246,255,.06);padding:12px;border-radius:12px;color:var(--mut);font-size:13px;line-height:1.6}
+.introNote{border:1px solid rgba(156,246,255,.22);background:rgba(156,246,255,.08);padding:14px;border-radius:14px;color:var(--mut);font-size:13px;line-height:1.6;box-shadow:inset 0 0 0 1px rgba(255,179,94,.08)}
 .introActions{justify-content:flex-end;margin-top:18px}
-.introActions .btn{min-width:200px}
+.introActions .btn{min-width:220px}
 .arches{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
-.arch{border:2px solid #2a3a58;background:linear-gradient(180deg,#141a23,#0e141c);border-radius:14px;overflow:hidden;cursor:pointer;display:flex;flex-direction:column;transition:transform .2s ease,outline .2s ease}
+.arch{border:2px solid rgba(255,179,94,.22);background:linear-gradient(180deg,rgba(14,19,26,.95),rgba(8,11,16,.9));border-radius:18px;overflow:hidden;cursor:pointer;display:flex;flex-direction:column;transition:transform .25s ease,outline .25s ease,box-shadow .25s ease;box-shadow:0 18px 32px rgba(0,0,0,.45)}
 .arch:active{transform:translateY(1px)}
-.arch img{width:100%;height:140px;object-fit:cover}
-.arch .pad{padding:12px;display:flex;flex-direction:column;gap:8px}
+.arch:hover{transform:translateY(-4px);box-shadow:0 26px 42px rgba(0,0,0,.5)}
+.arch img{width:100%;height:160px;object-fit:cover;filter:contrast(1.08) saturate(1.05)}
+.arch .pad{padding:16px;display:flex;flex-direction:column;gap:10px}
 .arch h3{margin:0 0 6px 0}
-.arch p{margin:.4em 0;color:var(--mut);font-size:13px}
-.arch .statrow{display:flex;gap:6px;padding:0 10px 10px 10px}
-.arch .b{border:1px solid var(--line);padding:3px 8px;border-radius:999px;font-size:12px}
-.arch[aria-selected="true"]{outline:3px solid var(--a)}
+.arch p{margin:.4em 0;color:var(--mut);font-size:13px;line-height:1.5}
+.arch .statrow{display:flex;gap:8px;padding:0 10px 10px 10px}
+.arch .b{border:1px solid rgba(255,179,94,.22);padding:4px 10px;border-radius:999px;font-size:12px;background:rgba(255,179,94,.08)}
+.arch[aria-selected="true"]{outline:3px solid var(--a);box-shadow:0 0 32px rgba(255,179,94,.4)}
 /* tabs visibility */
 [data-view="story"] .left,[data-view="story"] .right{display:none}
 [data-view="profile"] .mid,[data-view="profile"] .right{display:none}
@@ -148,41 +386,47 @@ a{color:var(--a)}
 }
 .choice .tags{pointer-events:none}
 .choice strong{display:block}
-.kabeGameBox{max-width:520px}
-.kabeGameIntro{margin:0 0 12px 0;color:var(--mut);line-height:1.6}
-.kabeGamePrompt{margin:0 0 12px 0;font-weight:600;color:var(--ink);line-height:1.5}
-.kabeGamePalette{display:grid;gap:10px;margin-bottom:8px}
-.kabeGamePalette .btn{width:100%;text-align:left;align-items:flex-start;flex-direction:column;gap:4px}
+.kabeGameBox{max-width:560px}
+.kabeGameIntro{margin:0 0 14px 0;color:var(--mut);line-height:1.7}
+.kabeGamePrompt{margin:0 0 14px 0;font-weight:600;color:var(--ink);line-height:1.6;text-transform:uppercase;letter-spacing:.6px}
+.kabeGamePalette{display:grid;gap:12px;margin-bottom:10px}
+.kabeGamePalette .btn{width:100%;text-align:left;align-items:flex-start;flex-direction:column;gap:6px;padding:14px;border-radius:14px;background:linear-gradient(135deg,rgba(16,21,29,.94),rgba(10,13,20,.9))}
 .kabeGamePalette .btn small{font-size:12px;color:var(--mut)}
-.kabeGamePalette .btn.selected{outline:2px solid var(--a)}
-.kabeGamePalette .btn.locked{opacity:.55;cursor:default}
-.kabeGestureLabel{display:flex;align-items:center;gap:8px;width:100%}
-.kabeGestureBadge{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:8px;background:var(--kabe-tone,var(--a));color:#050a16;font-size:13px;font-weight:700;letter-spacing:.3px;line-height:1;box-shadow:0 0 0 1px rgba(5,10,20,.35);flex-shrink:0}
+.kabeGamePalette .btn.selected{outline:2px solid var(--a);box-shadow:0 0 32px rgba(255,179,94,.3)}
+.kabeGamePalette .btn.locked{opacity:.5;cursor:default}
+.kabeGestureLabel{display:flex;align-items:center;gap:10px;width:100%}
+.kabeGestureBadge{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:10px;background:var(--kabe-tone,var(--a));color:#050a16;font-size:14px;font-weight:700;letter-spacing:.3px;line-height:1;box-shadow:0 0 0 1px rgba(5,10,20,.45);flex-shrink:0}
 .kabeGestureName{flex:1}
-.kabeGamePalette .btn.selected .kabeGestureBadge{box-shadow:0 0 0 2px rgba(156,246,255,.5)}
-.kabeGamePalette .btn.locked .kabeGestureBadge{opacity:.75}
-.kabeGameSequence{margin-top:4px;padding:10px;border-radius:12px;border:1px dashed var(--line);background:rgba(255,255,255,.03);display:flex;flex-direction:column;gap:6px}
-.kabeGameSequence .steps{display:flex;flex-direction:column;gap:6px}
-.kabeGameSequence .step{display:flex;flex-direction:column;gap:4px;padding:6px 8px;border-radius:8px;background:rgba(0,0,0,.14);border:1px solid rgba(156,246,255,.12);font-size:13px}
-.kabeGameSequence .step .kabeStepHeading{display:flex;align-items:center;gap:8px}
-.kabeGameSequence .step strong{font-size:12px;color:var(--mut)}
-.kabeGameSequence .step .kabeStepGesture{display:flex;align-items:center;gap:8px;font-weight:600}
-.kabeGameSequence .step.pending{opacity:.65;font-style:italic}
+.kabeGamePalette .btn.selected .kabeGestureBadge{box-shadow:0 0 0 3px rgba(156,246,255,.45)}
+.kabeGamePalette .btn.locked .kabeGestureBadge{opacity:.7}
+.kabeGameSequence{margin-top:6px;padding:14px;border-radius:14px;border:1px dashed rgba(255,179,94,.26);background:rgba(10,14,20,.6);display:flex;flex-direction:column;gap:8px;box-shadow:inset 0 0 0 1px rgba(119,244,255,.06)}
+.kabeGameSequence .steps{display:flex;flex-direction:column;gap:8px}
+.kabeGameSequence .step{display:flex;flex-direction:column;gap:6px;padding:8px 10px;border-radius:10px;background:rgba(0,0,0,.2);border:1px solid rgba(156,246,255,.18);font-size:13px;transition:transform .2s ease,box-shadow .2s ease}
+.kabeGameSequence .step:hover{transform:translateX(4px);box-shadow:0 0 20px rgba(119,244,255,.18)}
+.kabeGameSequence .step .kabeStepHeading{display:flex;align-items:center;gap:10px}
+.kabeGameSequence .step strong{font-size:12px;color:var(--mut);letter-spacing:.5px}
+.kabeGameSequence .step .kabeStepGesture{display:flex;align-items:center;gap:10px;font-weight:600}
+.kabeGameSequence .step.pending{opacity:.7;font-style:italic}
 .kabeGameSequence .step.pending .kabeStepGesture{font-weight:500}
-.kabeGameSequence .step.fail{border-color:var(--bad);color:var(--bad)}
-.kabeGameSequence .step.success{border-color:var(--good);color:var(--good)}
-.kabeGameSequence .step.fail .kabeGestureBadge{box-shadow:0 0 0 2px rgba(255,107,122,.45)}
-.kabeGameSequence .step.success .kabeGestureBadge{box-shadow:0 0 0 2px rgba(120,242,187,.4)}
-.kabeGameMessage{margin-top:12px;color:var(--mut);line-height:1.6}
-.kabeGameActions{justify-content:flex-end;margin-top:16px;flex-wrap:wrap;gap:10px}
-.kabeGameActions .btn{min-width:150px}
+.kabeGameSequence .step.fail{border-color:var(--bad);color:var(--bad);box-shadow:0 0 18px rgba(255,107,122,.25)}
+.kabeGameSequence .step.success{border-color:var(--good);color:var(--good);box-shadow:0 0 18px rgba(142,242,165,.25)}
+.kabeGameSequence .step.fail .kabeGestureBadge{box-shadow:0 0 0 3px rgba(255,107,122,.45)}
+.kabeGameSequence .step.success .kabeGestureBadge{box-shadow:0 0 0 3px rgba(120,242,187,.4)}
+.kabeGameMessage{margin-top:14px;color:var(--mut);line-height:1.7}
+.kabeGameActions{justify-content:flex-end;margin-top:18px;flex-wrap:wrap;gap:12px}
+.kabeGameActions .btn{min-width:160px}
 @media (max-width: 600px){
   body{font-size:14px}
-  .header{padding:12px 10px;gap:10px}
+  .header{padding:calc(9px + env(safe-area-inset-top,0px)) 10px 10px;gap:8px}
   .header .title{font-size:16px;line-height:1.25}
   .headerTop{gap:8px}
   .headerControls{gap:6px}
+  .headerCollapseBtn{width:100%;justify-content:space-between}
+  .headerMeta{gap:6px}
   .headerBadges{gap:6px}
+  .headerLore{font-size:11px}
+  .headerTicker{font-size:11px}
+  .headerTicker span{animation-duration:28s}
   .viewBadge{font-size:10px}
   .badge{font-size:10px}
   .tabbtn,.btn{font-size:14px;padding:10px}
@@ -207,21 +451,21 @@ a{color:var(--a)}
   .saveActions .btn{min-width:0;width:100%}
 }
 .mobilebar{display:none; position:fixed; left:0; right:0; bottom:0; z-index:30;
-  padding:8px 10px calc(8px + var(--safe-bottom)); gap:8px; justify-content:space-around;
-  background:linear-gradient(180deg,rgba(10,14,22,.1),rgba(10,14,22,.9)); backdrop-filter: blur(8px); border-top:1px solid var(--line);}
+  padding:10px 12px calc(12px + var(--safe-bottom)); gap:10px; justify-content:space-around;
+  background:linear-gradient(180deg,rgba(8,10,14,.35),rgba(5,6,8,.92)); backdrop-filter: blur(10px); border-top:1px solid rgba(255,179,94,.18); box-shadow:0 -12px 32px rgba(0,0,0,.45);}
 .mobilebar .tabbtn{flex:1; text-align:center}
 </style>
 </head>
 <body data-view="all">
-<header class="header">
+<header class="header" data-collapsed="false">
   <div class="headerTop">
     <div class="title">⟡ TRAME DOUCE — <span id="loc">Guillotière</span></div>
     <div class="headerControls">
       <span class="badge viewBadge" id="viewIndicator">Vue : Tous</span>
       <button class="btn ghost" id="asciiBtn">HUD ASCII ✓</button>
       <div class="menuWrap" id="navWrap">
-        <button class="iconBtn" id="navToggle" aria-haspopup="true" aria-expanded="false" aria-label="Changer de vue">⋯</button>
-        <div class="navMenu" id="navMenu" role="menu">
+        <button class="iconBtn" id="navToggle" aria-haspopup="true" aria-expanded="false" aria-label="Changer de vue" aria-controls="navMenu">⋯</button>
+        <div class="navMenu" id="navMenu" role="menu" aria-hidden="true">
           <button class="tabbtn" data-viewto="all" aria-pressed="true" role="menuitem">Tous</button>
           <button class="tabbtn" data-viewto="story" role="menuitem">Histoire</button>
           <button class="tabbtn" data-viewto="profile" role="menuitem">Profil</button>
@@ -229,12 +473,20 @@ a{color:var(--a)}
         </div>
       </div>
     </div>
+    <button class="headerCollapseBtn" id="headerCollapseBtn" type="button" aria-expanded="true" aria-controls="headerMeta" aria-label="Replier le briefing Sourdine">
+      <span class="collapseIcon" aria-hidden="true">▾</span>
+      <span class="collapseLabel">Briefing Sourdine</span>
+    </button>
   </div>
-  <div class="row headerBadges">
-    <span class="badge"><img class="icon" src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Heart_coraz%C3%B3n.svg/32px-Heart_coraz%C3%B3n.svg.png"> Stress <span id="stressVal">2</span>/5</span>
-    <span class="badge"><img class="icon" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/OOjs_UI_icon_firstaid-ltr.svg/32px-OOjs_UI_icon_firstaid-ltr.svg.png"> Blessures <span id="hpVal">5</span>/5</span>
-    <span class="badge"><img class="icon" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/Circle-icons-bulb.svg/32px-Circle-icons-bulb.svg.png"> Flux ◆ <span id="fluxVal">2</span></span>
-    <span class="badge"><img class="icon" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Noun_Project_document_icon_1409169_cc.svg/32px-Noun_Project_document_icon_1409169_cc.svg.png"> Fragments ✦ <span id="fragVal">2</span></span>
+  <div class="headerMeta" id="headerMeta">
+    <p class="headerLore">La pluie magnétique se mêle à la poussière rouge. Chaque décision illumine — ou condamne — les couloirs désertés.</p>
+    <div class="headerTicker" aria-hidden="true"><span>Transmission pirate : &nbsp; «&nbsp;Quartier sous quarantaine douce. Cherche signaux stables. Méfiance envers la milice de la Sourdine.&nbsp;» ✶ Transmission pirate : &nbsp; «&nbsp;Quartier sous quarantaine douce. Cherche signaux stables. Méfiance envers la milice de la Sourdine.&nbsp;»</span></div>
+    <div class="row headerBadges">
+      <span class="badge"><img class="icon" src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Heart_coraz%C3%B3n.svg/32px-Heart_coraz%C3%B3n.svg.png"> Stress <span id="stressVal">2</span>/5</span>
+      <span class="badge"><img class="icon" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/OOjs_UI_icon_firstaid-ltr.svg/32px-OOjs_UI_icon_firstaid-ltr.svg.png"> Blessures <span id="hpVal">5</span>/5</span>
+      <span class="badge"><img class="icon" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/Circle-icons-bulb.svg/32px-Circle-icons-bulb.svg.png"> Flux ◆ <span id="fluxVal">2</span></span>
+      <span class="badge"><img class="icon" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/Noun_Project_document_icon_1409169_cc.svg/32px-Noun_Project_document_icon_1409169_cc.svg.png"> Fragments ✦ <span id="fragVal">2</span></span>
+    </div>
   </div>
 </header>
 
@@ -461,6 +713,58 @@ const $=q=>document.querySelector(q);
 const navWrap=document.getElementById('navWrap');
 const navToggle=document.getElementById('navToggle');
 const navMenu=document.getElementById('navMenu');
+const header=document.querySelector('.header');
+const headerCollapseBtn=document.getElementById('headerCollapseBtn');
+const mobileHeaderMQ=window.matchMedia('(max-width: 900px)');
+let headerCollapsed=false;
+let lastScrollY=window.scrollY;
+function revealHeader(){if(header)header.classList.remove('header-hidden');}
+function setHeaderCollapsed(state){
+  if(!header)return;
+  headerCollapsed=!!state;
+  header.classList.toggle('collapsed',headerCollapsed);
+  header.setAttribute('data-collapsed',headerCollapsed?'true':'false');
+  if(headerCollapseBtn){
+    headerCollapseBtn.setAttribute('aria-expanded',headerCollapsed?'false':'true');
+    headerCollapseBtn.setAttribute('aria-label',headerCollapsed?'Déployer le briefing Sourdine':'Replier le briefing Sourdine');
+  }
+}
+function syncHeaderForViewport(){
+  if(!header)return;
+  if(mobileHeaderMQ.matches){
+    setHeaderCollapsed(true);
+    revealHeader();
+  }else{
+    setHeaderCollapsed(false);
+    revealHeader();
+  }
+  lastScrollY=window.scrollY;
+}
+function handleHeaderScroll(){
+  if(!header||!mobileHeaderMQ.matches)return;
+  const currentY=window.scrollY;
+  if(navWrap?.classList.contains('open')){lastScrollY=currentY;return;}
+  if(currentY>lastScrollY+16&&currentY>80){
+    header.classList.add('header-hidden');
+  }else if(currentY<lastScrollY-12||currentY<16){
+    header.classList.remove('header-hidden');
+  }
+  lastScrollY=currentY;
+}
+syncHeaderForViewport();
+if(typeof mobileHeaderMQ.addEventListener==='function'){
+  mobileHeaderMQ.addEventListener('change',()=>{syncHeaderForViewport();});
+}else if(typeof mobileHeaderMQ.addListener==='function'){
+  mobileHeaderMQ.addListener(()=>{syncHeaderForViewport();});
+}
+if(headerCollapseBtn){
+  headerCollapseBtn.addEventListener('click',()=>{
+    if(!mobileHeaderMQ.matches)return;
+    setHeaderCollapsed(!headerCollapsed);
+    revealHeader();
+  });
+}
+window.addEventListener('scroll',handleHeaderScroll,{passive:true});
 const slotLabel=idx=>String(idx+1).padStart(2,'0');
 const hasItem=name=>ST.inv.includes(name);
 function gainItem(name){
@@ -532,8 +836,19 @@ function setupFocusTrap(modalBox){
 document.querySelectorAll('.modalBox').forEach(setupFocusTrap);
 
 function updateViewIndicator(v){const badge=$('#viewIndicator'); if(badge){badge.textContent='Vue : '+(VIEW_LABELS[v]||'Tous');}}
-function openNavMenu(){if(!navWrap)return;navWrap.classList.add('open');if(navToggle)navToggle.setAttribute('aria-expanded','true');}
-function closeNavMenu(){if(!navWrap)return;navWrap.classList.remove('open');if(navToggle)navToggle.setAttribute('aria-expanded','false');}
+function openNavMenu(){
+  if(!navWrap)return;
+  revealHeader();
+  navWrap.classList.add('open');
+  if(navToggle)navToggle.setAttribute('aria-expanded','true');
+  if(navMenu)navMenu.setAttribute('aria-hidden','false');
+}
+function closeNavMenu(){
+  if(!navWrap)return;
+  navWrap.classList.remove('open');
+  if(navToggle)navToggle.setAttribute('aria-expanded','false');
+  if(navMenu)navMenu.setAttribute('aria-hidden','true');
+}
 function toggleNavMenu(){if(navWrap?.classList.contains('open')){closeNavMenu();}else{openNavMenu();}}
 updateViewIndicator(document.body.getAttribute('data-view')||'all');
 if(navToggle){navToggle.addEventListener('click',e=>{e.stopPropagation();toggleNavMenu();});}


### PR DESCRIPTION
## Summary
- collapse the lore and stat briefing on mobile with a toggle button and scroll-aware header behavior so navigation is no longer obstructed
- refresh the nav menu accessibility, aria states, and animations while extending the atmospheric post-apo glow across the layout
- add animated background treatments and responsive tweaks to strengthen the post-apocalyptic mood on small and large screens

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfeaf3481083319afce3553dab3688