### PR TITLE
Refresh HUD after archetype confirm

### DIFF
--- a/index.html
+++ b/index.html
@@ -2029,6 +2029,7 @@ function openArch(){
 function selectArch(a,card){ sel=a; document.querySelectorAll('.arch').forEach(x=>x.setAttribute('aria-selected','false')); card.setAttribute('aria-selected','true'); $('#btnConfirm').disabled=false; }
 $('#btnRandom').addEventListener('click',()=>{const i=Math.floor(Math.random()*ARCH.length);selectArch(ARCH[i], document.querySelectorAll('.arch')[i])});
 $('#btnConfirm').addEventListener('click',()=>{ ST.arch=sel; ST.stats={...sel.stats}; ST.skills={...sel.skills}; ST.inv=[...sel.start];
+  bars(); renderStats(); renderAscii();
   addObj('Archétype: '+sel.name); const modal=document.getElementById('archModal'); if(modal){modal.style.display='none';}
   const intro=document.getElementById('introModal'); if(intro){intro.style.display='none';intro.setAttribute('aria-hidden','true');}
   save(); render(); restoreFocus(archReturnFocus); archReturnFocus=null; });


### PR DESCRIPTION
## Summary
- refresh the HUD panels immediately after confirming an archetype selection
- trigger stat, ASCII HUD, and bar renders before persisting and rerendering the story view

## Testing
- browser_container.run_playwright_script (manual archetype confirmation check)


------
https://chatgpt.com/codex/tasks/task_e_68d00a16f9dc8331b29ac9f08b2e9c5d