### PR TITLE
Allow collapsing the sticky header on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@ a{color:var(--a)}
   pointer-events:none;
 }
 .headerCollapseBtn{
-  display:none;
+  display:inline-flex;
   align-items:center;
   gap:8px;
   margin-left:auto;
@@ -177,7 +177,7 @@ a{color:var(--a)}
 .header .title{font-weight:800;letter-spacing:.6px;flex:1;display:flex;align-items:center;gap:10px;text-transform:uppercase;text-shadow:0 0 18px rgba(101,241,221,.3)}
 .header .title span{letter-spacing:1.2px}
 #loc{color:var(--glow)}
-.headerControls{display:flex;align-items:center;gap:8px;margin-left:auto;flex-wrap:wrap}
+.headerControls{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
 .headerBadges{gap:8px;flex-wrap:wrap;width:100%}
 .headerLore{margin:2px 0 4px 0;color:var(--mut);font-size:13px;max-width:620px;line-height:1.6}
 .headerTicker{position:relative;overflow:hidden;border:1px solid rgba(255,179,94,.24);border-radius:10px;padding:6px 0;background:rgba(12,16,22,.7);box-shadow:inset 0 0 0 1px rgba(119,244,255,.08);margin-top:4px}
@@ -770,7 +770,6 @@ if(typeof mobileHeaderMQ.addEventListener==='function'){
 }
 if(headerCollapseBtn){
   headerCollapseBtn.addEventListener('click',()=>{
-    if(!mobileHeaderMQ.matches)return;
     setHeaderCollapsed(!headerCollapsed);
     revealHeader();
   });


### PR DESCRIPTION
## Summary
- show the header collapse control on large screens and keep the layout aligned in the header bar
- allow the collapse handler to run outside the mobile breakpoint so desktop users can hide the briefing

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d00c6ef8c48331a6a20d99d62c2bd9